### PR TITLE
Fix DNSc_GetHost() call in DNScCmd_GetHost()

### DIFF
--- a/Cmd/dns-c_cmd.c
+++ b/Cmd/dns-c_cmd.c
@@ -255,6 +255,8 @@ CPU_INT16S  DNScCmd_GetHost (CPU_INT16U        argc,
 
 
     status = DNSc_GetHost(p_argv[1],
+                          DEF_NULL,
+                          (CPU_INT32U)0,
                           addrs,
                          &addr_ctr,
                           DNSc_FLAG_NONE,


### PR DESCRIPTION
Add missing parameters p_res_host_name and res_hostname_len, and set them to null.

According with DNSc_GetHost() documentation:

> This argument should be left DEF_NULL if a simple forward DNS request is desired.

This should close #1 